### PR TITLE
Fix POSTMAN collection link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ $ uvicorn main:app --reload --host 0.0.0.0 --port 5000
 
 ## POSTMAN Collection
 
-Download the POSTMAN collection from [/assets/mini-rag-app.postman_collection.json](/assets/mini-rag-app.postman_collection.json)
+Download the POSTMAN collection from [src/assets/mini-rag-app.postman_collection.json](src/assets/mini-rag-app.postman_collection.json)


### PR DESCRIPTION
## Summary
- update README to point to the POSTMAN collection under `src/assets`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685724642764832baab7091cde028d98